### PR TITLE
Detect debug builds not by name but its property

### DIFF
--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -27,8 +27,7 @@ android {
 }
 
 android.libraryVariants.all { variant ->
-    def name = variant.buildType.name
-    if (name.equals(com.android.builder.core.BuilderConstants.DEBUG)) {
+    if (variant.buildType.isDebuggable()) {
         return; // Skip debug builds.
     }
     task("javadoc${variant.name.capitalize()}", type: Javadoc) {


### PR DESCRIPTION
If another build type which is initialized with debug is added,
it also should be treated as debug build.
