### PR TITLE
Remove applicationId from library project

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -5,7 +5,6 @@ android {
     buildToolsVersion "21.1.1"
 
     defaultConfig {
-        applicationId "com.cookpad.puree.plugins"
         minSdkVersion 10
         targetSdkVersion 21
         versionCode 1

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -7,7 +7,6 @@ android {
     buildToolsVersion "21.1.1"
 
     defaultConfig {
-        applicationId "com.cookpad.puree"
         minSdkVersion 10
         targetSdkVersion 21
         versionCode 1


### PR DESCRIPTION
Specifying applicationId in library project is meaningless.
As of 1.0.0-rc1, setting applicationId in library project causes build failure.
see http://tools.android.com/tech-docs/new-build-system
