### PR TITLE
Use return value of last filter when multiple filters are registered.

### DIFF
--- a/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeOutputTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeOutputTest.java
@@ -1,0 +1,96 @@
+package com.cookpad.puree.outputs;
+
+import android.test.AndroidTestCase;
+
+import com.cookpad.puree.OutputConfiguration;
+import com.cookpad.puree.PureeFilter;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class PureeOutputTest extends AndroidTestCase {
+
+    public void testFilter_discardLog() {
+        final PureeOutput output = new PureeOutput() {
+            @Override
+            public void emit(JSONObject jsonLog) {
+                // because first filter discards log.
+                fail("log should be discarded by first filter");
+            }
+
+            @Override
+            public OutputConfiguration configure(OutputConfiguration conf) {
+                return conf;
+            }
+
+            @Override
+            public String type() {
+                return "output";
+            }
+        };
+        output.registerFilter(new PureeFilter() {
+            @Override
+            public JSONObject apply(JSONObject jsonLog) throws JSONException {
+                // discard log
+                return null;
+            }
+        });
+        output.registerFilter(new PureeFilter() {
+            @Override
+            public JSONObject apply(JSONObject jsonLog) throws JSONException {
+                return jsonLog.put("event_time", System.currentTimeMillis());
+            }
+        });
+
+        output.receive(new JSONObject());
+    }
+
+    public void testFilter_multipleModifications() throws JSONException {
+
+        final AtomicReference<JSONObject> result = new AtomicReference<>();
+
+        final PureeOutput output = new PureeOutput() {
+            @Override
+            public void emit(JSONObject jsonLog) {
+                result.set(jsonLog);
+            }
+
+            @Override
+            public OutputConfiguration configure(OutputConfiguration conf) {
+                return conf;
+            }
+
+            @Override
+            public String type() {
+                return "output";
+            }
+        };
+        output.registerFilter(new PureeFilter() {
+            @Override
+            public JSONObject apply(JSONObject jsonLog) throws JSONException {
+                final JSONObject jsonObject = new JSONObject();
+                return jsonObject.put("filter1", "foo");
+            }
+        });
+        output.registerFilter(new PureeFilter() {
+            @Override
+            public JSONObject apply(JSONObject jsonLog) throws JSONException {
+                final JSONObject jsonObject = new JSONObject();
+                if (jsonLog.has("filter1")) {
+                    jsonObject.put("filter1", jsonLog.getString("filter1"));
+                }
+                return jsonLog.put("filter2", "bar");
+            }
+        });
+
+        output.receive(new JSONObject());
+
+        final JSONObject resultObject = result.get();
+        assertTrue("value from \"filter1\" not found", resultObject.has("filter1"));
+        assertEquals("", "foo", resultObject.getString("filter1"));
+        assertTrue("value from \"filter2\" not found", resultObject.has("filter2"));
+        assertEquals("bar", resultObject.getString("filter2"));
+    }
+}

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeOutput.java
@@ -38,13 +38,12 @@ public abstract class PureeOutput {
     }
 
     protected JSONObject applyFilters(JSONObject jsonLog) throws JSONException {
-        if (filters == null || filters.isEmpty()) {
-            return jsonLog;
-        }
-
-        JSONObject filteredLog = new JSONObject();
+        JSONObject filteredLog = jsonLog;
         for (PureeFilter filter : filters) {
-            filteredLog = filter.apply(jsonLog);
+            filteredLog = filter.apply(filteredLog);
+            if (filteredLog == null) {
+                return null;
+            }
         }
         return filteredLog;
     }


### PR DESCRIPTION
problem 1.
  filter's return value null is ignored if one of following filters returns non-null value;

problem 2.
  if filter returns new object instead of 'jsonLog' argument and following filter exists,
  the returned value is overwritten by value from following filters.
