### PR TITLE
Use selectionArg(query parameter) instead of String concatination.

### DIFF
--- a/puree/src/main/java/com/cookpad/puree/storage/PureeDbHelper.java
+++ b/puree/src/main/java/com/cookpad/puree/storage/PureeDbHelper.java
@@ -32,10 +32,10 @@ public class PureeDbHelper extends SQLiteOpenHelper implements PureeStorage {
 
     public Records select(String type, int logsPerRequest) {
         String query = "SELECT * FROM " + TABLE_NAME +
-                " WHERE " + COLUMN_NAME_TYPE + " = '" + type + "'" +
+                " WHERE " + COLUMN_NAME_TYPE + " = ?" +
                 " ORDER BY id ASC" +
                 " LIMIT " + logsPerRequest;
-        Cursor cursor = db.rawQuery(query, null);
+        Cursor cursor = db.rawQuery(query, new String[]{type});
 
         try {
             return recordsFromCursor(cursor);


### PR DESCRIPTION
Puree crashes if output type contains single quote character because of invalid SQL query string.
