### PR TITLE
Remove the dependency to Gson

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -27,6 +27,8 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.0.0'
+    compile 'com.google.code.gson:gson:2.3'
+
     compile project(':puree')
     compile project(':plugins')
 }

--- a/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
+++ b/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
@@ -2,6 +2,8 @@ package com.example.puree.logs;
 
 import android.content.Context;
 
+import com.cookpad.puree.JsonConvertible;
+import com.cookpad.puree.JsonStringifier;
 import com.cookpad.puree.Puree;
 import com.cookpad.puree.PureeConfiguration;
 import com.cookpad.puree.PureeFilter;
@@ -9,6 +11,7 @@ import com.cookpad.puree.plugins.OutBufferedLogcat;
 import com.cookpad.puree.plugins.OutLogcat;
 import com.example.puree.AddEventTimeFilter;
 import com.example.puree.logs.plugins.OutDisplay;
+import com.google.gson.Gson;
 
 public class PureeConfigurator {
     public static void configure(Context context) {
@@ -22,6 +25,13 @@ public class PureeConfigurator {
                 .source(ClickLog.class).filter(addEventTimeFilter).to(new OutBufferedLogcat())
                 .source(PvLog.class).filter(addEventTimeFilter).to(new OutLogcat())
 //                .registerOutput(new OutDisplay(), new SamplingFilter(0.5F)) // you can sampling logs
+                .jsonStringifier(new JsonStringifier() {
+                    private final Gson gson = new Gson();
+                    @Override
+                    public String toJson(JsonConvertible jsonConvertible) {
+                        return gson.toJson(jsonConvertible);
+                    }
+                })
                 .build();
         conf.printMapping();
         return conf;

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -52,8 +52,8 @@ android.libraryVariants.all { variant ->
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.code.gson:gson:2.3'
 
+    androidTestCompile 'com.google.code.gson:gson:2.3'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
 }

--- a/puree/src/androidTest/java/com/cookpad/puree/PureeConfigurationTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/PureeConfigurationTest.java
@@ -6,6 +6,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import com.cookpad.puree.outputs.OutputConfiguration;
 import com.cookpad.puree.outputs.PureeOutput;
+import com.google.gson.Gson;
 
 import org.hamcrest.Matchers;
 import org.json.JSONException;
@@ -19,10 +20,13 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class PureeConfigurationTest {
+
     @Test
     public void checkDefaultValue() {
         Context context = InstrumentationRegistry.getContext();
@@ -30,7 +34,7 @@ public class PureeConfigurationTest {
                 .build();
 
         assertThat(conf.getApplicationContext(), notNullValue());
-        assertThat(conf.getGson(), notNullValue());
+        assertThat(conf.getJsonStringifier(), nullValue());
 
         Map<Key, List<PureeOutput>> sourceOutputMap = conf.getSourceOutputMap();
         assertThat(sourceOutputMap.size(), is(0));
@@ -44,6 +48,14 @@ public class PureeConfigurationTest {
                 .source(FooLog.class).filters(new FooFilter()).to(new OutFoo())
                 .source(FooLog.class).filter(new FooFilter()).filter(new BarFilter()).to(new OutBar())
                 .source(BarLog.class).filter(new FooFilter()).to(new OutFoo())
+                .jsonStringifier(new JsonStringifier() {
+                    private final Gson gson = new Gson();
+
+                    @Override
+                    public String toJson(JsonConvertible jsonConvertible) {
+                        return gson.toJson(jsonConvertible);
+                    }
+                })
                 .build();
 
         Map<Key, List<PureeOutput>> sourceOutputMap = conf.getSourceOutputMap();

--- a/puree/src/main/java/com/cookpad/puree/JsonConvertible.java
+++ b/puree/src/main/java/com/cookpad/puree/JsonConvertible.java
@@ -1,14 +1,12 @@
 package com.cookpad.puree;
 
-import com.google.gson.Gson;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public abstract class JsonConvertible {
-    public JSONObject toJson(Gson gson) {
+    public JSONObject toJson(JsonStringifier jsonStringifier) {
         try {
-            return new JSONObject(gson.toJson(this));
+            return new JSONObject(jsonStringifier.toJson(this));
         } catch (JSONException e) {
             return new JSONObject();
         }

--- a/puree/src/main/java/com/cookpad/puree/JsonConvertible.java
+++ b/puree/src/main/java/com/cookpad/puree/JsonConvertible.java
@@ -5,6 +5,11 @@ import org.json.JSONObject;
 
 public abstract class JsonConvertible {
     public JSONObject toJson(JsonStringifier jsonStringifier) {
+        if (jsonStringifier == null) {
+            // Override me or set JsonStringifier to PureeConfiguration
+            return new JSONObject();
+        }
+
         try {
             return new JSONObject(jsonStringifier.toJson(this));
         } catch (JSONException e) {

--- a/puree/src/main/java/com/cookpad/puree/JsonStringifier.java
+++ b/puree/src/main/java/com/cookpad/puree/JsonStringifier.java
@@ -1,0 +1,11 @@
+package com.cookpad.puree;
+
+public interface JsonStringifier {
+    /**
+     * Convert an instance to JSON formatted string.
+     *
+     * @param jsonConvertible to be converted to JSON formatted string
+     * @return JSON formatted string as an object like '{"key": "type"}'
+     */
+    String toJson(JsonConvertible jsonConvertible);
+}

--- a/puree/src/main/java/com/cookpad/puree/Puree.java
+++ b/puree/src/main/java/com/cookpad/puree/Puree.java
@@ -8,7 +8,6 @@ import com.cookpad.puree.outputs.PureeOutput;
 import com.cookpad.puree.storage.PureeDbHelper;
 import com.cookpad.puree.storage.PureeStorage;
 import com.cookpad.puree.storage.Records;
-import com.google.gson.Gson;
 
 import java.util.HashMap;
 import java.util.List;
@@ -18,7 +17,7 @@ public class Puree {
     private static final String TAG = Puree.class.getSimpleName();
 
     private static boolean isInitialized = false;
-    private static Gson gson;
+    private static JsonStringifier jsonStringifier;
     private static PureeStorage storage;
     private static Map<Key, List<PureeOutput>> sourceOutputMap = new HashMap<>();
 
@@ -28,7 +27,7 @@ public class Puree {
             return;
         }
 
-        gson = conf.getGson();
+        jsonStringifier = conf.getJsonStringifier();
         storage = new PureeDbHelper(conf.getApplicationContext());
         sourceOutputMap = conf.getSourceOutputMap();
 
@@ -51,7 +50,7 @@ public class Puree {
         Key key = Key.from(log.getClass());
         List<PureeOutput> outputs = sourceOutputMap.get(key);
         for (PureeOutput output : outputs) {
-            output.receive(log.toJson(gson));
+            output.receive(log.toJson(jsonStringifier));
         }
     }
 

--- a/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
+++ b/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
@@ -53,7 +53,7 @@ public class PureeConfiguration {
         }
 
         /**
-         * Specify the {@link com.google.gson.Gson} to serialize logs.
+         * Specify the {@link com.cookpad.puree.JsonStringifier} to serialize logs.
          */
         public Builder jsonStringifier(JsonStringifier jsonStringifier) {
             this.jsonStringifier = jsonStringifier;

--- a/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
+++ b/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import com.cookpad.puree.internal.LogDumper;
 import com.cookpad.puree.outputs.PureeOutput;
-import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -13,24 +12,24 @@ import java.util.Map;
 
 public class PureeConfiguration {
     private Context applicationContext;
-    private Gson gson;
+    private JsonStringifier jsonStringifier;
     private Map<Key, List<PureeOutput>> sourceOutputMap;
 
     public Context getApplicationContext() {
         return applicationContext;
     }
 
-    public Gson getGson() {
-        return gson;
+    public JsonStringifier getJsonStringifier() {
+        return jsonStringifier;
     }
 
     public Map<Key, List<PureeOutput>> getSourceOutputMap() {
         return sourceOutputMap;
     }
 
-    PureeConfiguration(Context context, Gson gson, Map<Key, List<PureeOutput>> sourceOutputMap) {
+    PureeConfiguration(Context context, JsonStringifier jsonStringifier, Map<Key, List<PureeOutput>> sourceOutputMap) {
         this.applicationContext = context.getApplicationContext();
-        this.gson = gson;
+        this.jsonStringifier = jsonStringifier;
         this.sourceOutputMap = sourceOutputMap;
     }
 
@@ -43,7 +42,7 @@ public class PureeConfiguration {
 
     public static class Builder {
         private Context context;
-        private Gson gson = new Gson();
+        private JsonStringifier jsonStringifier;
         private Map<Key, List<PureeOutput>> sourceOutputMap = new HashMap<>();
 
         /**
@@ -56,8 +55,8 @@ public class PureeConfiguration {
         /**
          * Specify the {@link com.google.gson.Gson} to serialize logs.
          */
-        public Builder gson(Gson gson) {
-            this.gson = gson;
+        public Builder jsonStringifier(JsonStringifier jsonStringifier) {
+            this.jsonStringifier = jsonStringifier;
             return this;
         }
 
@@ -88,7 +87,7 @@ public class PureeConfiguration {
          * Create the {@link com.cookpad.puree.PureeConfiguration} instance.
          */
         public PureeConfiguration build() {
-            return new PureeConfiguration(context, gson, sourceOutputMap);
+            return new PureeConfiguration(context, jsonStringifier, sourceOutputMap);
         }
     }
 }


### PR DESCRIPTION
Hello,
Thanks for that nice library.
But Gson is not the only one library to handle JSON, and as is well known, using several libraries for the same purpose is not fitting to build apks, so implicitly depending to such a library is not good.

I remove the dependency to Gson by default because of above, though the compatibility is lost. I hope the implicit dependency is removed anyway, so this request is simply to acknowledge that.

Thanks.