### PR TITLE
add PureeConfiguration#register() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Puree helps you unify your logging infrastructure.
 
 ### Initialize
 
-Configure Puree on application created.
+Configure Puree with `PureeConfiguration` in `Application#onCreate()`.
 
 ```java
 public class DemoApplication extends Application {
@@ -30,8 +30,8 @@ public class DemoApplication extends Application {
     public static PureeConfiguration buildConfiguration(Context context) {
         PureeFilter addEventTimeFilter = new AddEventTimeFilter();
         return new PureeConfiguration.Builder(context)
-                .source(ClickLog.class).to(new OutLogcat())
-                .source(ClickLog.class).filter(addEventTimeListener).to(new OutBufferedLogcat())
+                .register(ClickLog.class, new OutLogcat())
+                .register(ClickLog.class, new OutBufferedLogcat().withFilters(addEventTimeListener))
                 .build();
     }
 }

--- a/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
+++ b/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
@@ -6,6 +6,7 @@ import com.cookpad.puree.PureeFilter;
 import com.cookpad.puree.plugins.OutBufferedLogcat;
 import com.cookpad.puree.plugins.OutLogcat;
 import com.example.puree.AddEventTimeFilter;
+import com.example.puree.logs.filters.SamplingFilter;
 import com.example.puree.logs.plugins.OutDisplay;
 
 import android.content.Context;
@@ -17,11 +18,12 @@ public class PureeConfigurator {
 
     public static PureeConfiguration buildConf(Context context) {
         PureeFilter addEventTimeFilter = new AddEventTimeFilter();
+        PureeFilter samplingFilter = new SamplingFilter(1.0f);
         PureeConfiguration conf = new PureeConfiguration.Builder(context)
-                .source(ClickLog.class).to(new OutDisplay())
-                .source(ClickLog.class).filter(addEventTimeFilter).to(new OutBufferedLogcat())
-                .source(PvLog.class).filter(addEventTimeFilter).to(new OutLogcat())
-//                .register(new OutDisplay(), new SamplingFilter(0.5F)) // you can sampling logs
+                .register(ClickLog.class, new OutDisplay().withFilters(addEventTimeFilter))
+                .register(ClickLog.class,
+                        new OutBufferedLogcat().withFilters(addEventTimeFilter, samplingFilter))
+                .register(PvLog.class, new OutLogcat().withFilters(addEventTimeFilter))
                 .build();
         conf.printMapping();
         return conf;

--- a/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
+++ b/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
@@ -1,7 +1,5 @@
 package com.example.puree.logs;
 
-import android.content.Context;
-
 import com.cookpad.puree.Puree;
 import com.cookpad.puree.PureeConfiguration;
 import com.cookpad.puree.PureeFilter;
@@ -9,6 +7,8 @@ import com.cookpad.puree.plugins.OutBufferedLogcat;
 import com.cookpad.puree.plugins.OutLogcat;
 import com.example.puree.AddEventTimeFilter;
 import com.example.puree.logs.plugins.OutDisplay;
+
+import android.content.Context;
 
 public class PureeConfigurator {
     public static void configure(Context context) {
@@ -21,7 +21,7 @@ public class PureeConfigurator {
                 .source(ClickLog.class).to(new OutDisplay())
                 .source(ClickLog.class).filter(addEventTimeFilter).to(new OutBufferedLogcat())
                 .source(PvLog.class).filter(addEventTimeFilter).to(new OutLogcat())
-//                .registerOutput(new OutDisplay(), new SamplingFilter(0.5F)) // you can sampling logs
+//                .register(new OutDisplay(), new SamplingFilter(0.5F)) // you can sampling logs
                 .build();
         conf.printMapping();
         return conf;

--- a/demo/src/main/java/com/example/puree/logs/plugins/OutDisplay.java
+++ b/demo/src/main/java/com/example/puree/logs/plugins/OutDisplay.java
@@ -7,6 +7,9 @@ import org.json.JSONObject;
 
 import java.lang.ref.WeakReference;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class OutDisplay extends PureeOutput {
     public static final String TYPE = "display";
 

--- a/plugins/src/main/java/com/cookpad/puree/plugins/OutBufferedLogcat.java
+++ b/plugins/src/main/java/com/cookpad/puree/plugins/OutBufferedLogcat.java
@@ -1,13 +1,17 @@
 package com.cookpad.puree.plugins;
 
-import android.util.Log;
-
+import com.cookpad.puree.async.AsyncResult;
 import com.cookpad.puree.outputs.OutputConfiguration;
 import com.cookpad.puree.outputs.PureeBufferedOutput;
-import com.cookpad.puree.async.AsyncResult;
 
 import org.json.JSONArray;
 
+import android.util.Log;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+
+
+@ParametersAreNonnullByDefault
 public class OutBufferedLogcat extends PureeBufferedOutput {
     public static final String TYPE = "buffered_logcat";
 

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -39,7 +39,8 @@ android.libraryVariants.all { variant ->
     task("javadoc${variant.name.capitalize()}", type: Javadoc) {
         description "Generates Javadoc for $variant.name."
         source = variant.javaCompile.source
-        ext.androidJar = System.getenv("ANDROID_HOME") + "/platforms/${android.compileSdkVersion}/android.jar"
+        ext.androidJar = System.getenv("ANDROID_HOME") +
+                "/platforms/${android.compileSdkVersion}/android.jar"
         classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
     }
 
@@ -51,8 +52,8 @@ android.libraryVariants.all { variant ->
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.google.code.gson:gson:2.3'
+    compile 'com.google.code.findbugs:jsr305:3.0.0'
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
     androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
@@ -85,7 +86,8 @@ publishing {
             pom.withXml {
                 Node root = asNode()
                 root.appendNode('name', 'puree')
-                root.appendNode('description', 'Puree is a data collector for unified logging layer for Android.')
+                root.appendNode('description',
+                        'Puree is a data collector for unified logging layer for Android.')
                 root.appendNode('url', 'https://github.com/cookpad/puree-android')
 
                 def issues = root.appendNode('issueManagement')
@@ -99,7 +101,8 @@ publishing {
 
                 def license = root.appendNode('licenses').appendNode('license')
                 license.appendNode('name', 'MIT')
-                license.appendNode('url', 'https://raw.githubusercontent.com/cookpad/puree-android/master/LICENSE.txt')
+                license.appendNode('url',
+                        'https://raw.githubusercontent.com/cookpad/puree-android/master/LICENSE.txt')
                 license.appendNode('distribution', 'repo')
             }
         }

--- a/puree/src/main/java/com/cookpad/puree/Key.java
+++ b/puree/src/main/java/com/cookpad/puree/Key.java
@@ -1,7 +1,8 @@
 package com.cookpad.puree;
 
 public class Key {
-    private String id;
+
+    private final String id;
 
     public String getId() {
         return id;

--- a/puree/src/main/java/com/cookpad/puree/Puree.java
+++ b/puree/src/main/java/com/cookpad/puree/Puree.java
@@ -1,6 +1,6 @@
 package com.cookpad.puree;
 
-import android.util.Log;
+import com.google.gson.Gson;
 
 import com.cookpad.puree.exceptions.PureeNotInitializedException;
 import com.cookpad.puree.internal.LogDumper;
@@ -8,7 +8,8 @@ import com.cookpad.puree.outputs.PureeOutput;
 import com.cookpad.puree.storage.PureeDbHelper;
 import com.cookpad.puree.storage.PureeStorage;
 import com.cookpad.puree.storage.Records;
-import com.google.gson.Gson;
+
+import android.util.Log;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +21,7 @@ public class Puree {
     private static boolean isInitialized = false;
     private static Gson gson;
     private static PureeStorage storage;
+
     private static Map<Key, List<PureeOutput>> sourceOutputMap = new HashMap<>();
 
     public static synchronized void initialize(PureeConfiguration conf) {

--- a/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
+++ b/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
@@ -1,20 +1,27 @@
 package com.cookpad.puree;
 
-import android.content.Context;
+import com.google.gson.Gson;
 
 import com.cookpad.puree.internal.LogDumper;
 import com.cookpad.puree.outputs.PureeOutput;
-import com.google.gson.Gson;
+
+import android.content.Context;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class PureeConfiguration {
-    private Context applicationContext;
-    private Gson gson;
-    private Map<Key, List<PureeOutput>> sourceOutputMap;
+
+    private final Context applicationContext;
+
+    private final Gson gson;
+
+    private final Map<Key, List<PureeOutput>> sourceOutputMap;
 
     public Context getApplicationContext() {
         return applicationContext;
@@ -43,7 +50,9 @@ public class PureeConfiguration {
 
     public static class Builder {
         private Context context;
-        private Gson gson = new Gson();
+
+        private Gson gson;
+
         private Map<Key, List<PureeOutput>> sourceOutputMap = new HashMap<>();
 
         /**
@@ -62,32 +71,37 @@ public class PureeConfiguration {
         }
 
         /**
-         * Specify the source class of log.
+         * Specify a source class of logs, which returns {@link Source} an
+         * {@link Source#to(PureeOutput)} must be called to register an output plugin.
          */
-        public Source source(Class<? extends JsonConvertible> clazz) {
-            Key key = Key.from(clazz);
-            return new Source(this, key);
+        public Source source(Class<? extends JsonConvertible> logClass) {
+            return new Source(this, Key.from(logClass));
         }
 
-        void registerOutput(Key key, PureeOutput output, List<PureeFilter> filters) {
-            if (filters != null) {
-                for (PureeFilter filter : filters) {
-                    output.registerFilter(filter);
-                }
-            }
+        /**
+         * @return the builder itself
+         */
+        public Builder register(Class<? extends JsonConvertible> logClass, PureeOutput output) {
+            return register(Key.from(logClass), output);
+        }
 
+        Builder register(Key key, PureeOutput output) {
             List<PureeOutput> outputs = sourceOutputMap.get(key);
             if (outputs == null) {
                 outputs = new ArrayList<>();
             }
             outputs.add(output);
             sourceOutputMap.put(key, outputs);
+            return this;
         }
 
         /**
          * Create the {@link com.cookpad.puree.PureeConfiguration} instance.
          */
         public PureeConfiguration build() {
+            if (gson == null) {
+                gson = new Gson();
+            }
             return new PureeConfiguration(context, gson, sourceOutputMap);
         }
     }

--- a/puree/src/main/java/com/cookpad/puree/Source.java
+++ b/puree/src/main/java/com/cookpad/puree/Source.java
@@ -30,7 +30,7 @@ public class Source {
 
     /** Specify the {@link com.cookpad.puree.outputs.PureeOutput} that is responded to source. */
     public PureeConfiguration.Builder to(PureeOutput output) {
-        builder.registerOutput(key, output, filters);
+        builder.register(key, output.withFilters(filters));
         return builder;
     }
 }

--- a/puree/src/main/java/com/cookpad/puree/internal/LogDumper.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/LogDumper.java
@@ -1,13 +1,13 @@
 package com.cookpad.puree.internal;
 
-import android.util.Log;
-
 import com.cookpad.puree.Key;
 import com.cookpad.puree.PureeFilter;
 import com.cookpad.puree.outputs.PureeOutput;
 import com.cookpad.puree.storage.Records;
 
 import org.json.JSONException;
+
+import android.util.Log;
 
 import java.util.List;
 import java.util.Map;

--- a/puree/src/main/java/com/cookpad/puree/outputs/OutputConfiguration.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/OutputConfiguration.java
@@ -1,5 +1,8 @@
 package com.cookpad.puree.outputs;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class OutputConfiguration {
     private int flushIntervalMillis = 2 * 60 * 1000; // 2 minutes
     private int logsPerRequest = 100;

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
@@ -11,6 +11,9 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public abstract class PureeBufferedOutput extends PureeOutput {
     private RetryableTaskRunner retryableTaskRunner;
 

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeOutput.java
@@ -7,8 +7,13 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public abstract class PureeOutput {
     protected OutputConfiguration conf;
     protected PureeStorage storage;
@@ -17,6 +22,17 @@ public abstract class PureeOutput {
     public void registerFilter(PureeFilter filter) {
         filters.add(filter);
     }
+
+    public PureeOutput withFilters(PureeFilter... filters) {
+        Collections.addAll(this.filters, filters);
+        return this;
+    }
+
+    public PureeOutput withFilters(Collection<PureeFilter> filters) {
+        this.filters.addAll(filters);
+        return this;
+    }
+
 
     public List<PureeFilter> getFilters() {
         return filters;


### PR DESCRIPTION
`#register()` is an alternative interface to `#source().to()`. What do you think of it?

I think `#source()` is confusing because it does not return `PureeConfiguration.Builder` even if it seems a builder pattern. In fact, I can't understand how it works in the first impression.

`register(FooLog.class, new FooOutput().withFilter(...))`, instead, shows it requires a pair of (1) a JsonConvertible log class and (2) a PureeOutput class which might have some filter classes.

## Usage

From PureeConfigurationTest.java:

### current

```java
        PureeConfiguration conf = new PureeConfiguration.Builder(context)
                .source(FooLog.class).to(new OutFoo())
                .source(FooLog.class).filters(new FooFilter()).to(new OutFoo())
                .source(FooLog.class).filter(new FooFilter()).filter(new BarFilter()).to(new OutBar())
                .source(BarLog.class).filter(new FooFilter()).to(new OutFoo())
                .build();
```

### new

```java
        PureeConfiguration conf = new PureeConfiguration.Builder(context)
                .register(FooLog.class, new OutFoo())
                .register(FooLog.class, new OutFoo().withFilters(new FooFilter()))
                .register(FooLog.class, new OutBar().withFilters(new FooFilter(), new BarFilter()))
                .register(BarLog.class, new OutFoo().withFilters(new FooFilter()))
                .build();
```

## Backward Compatibility

This PR keeps backward compatibility.