### PR TITLE
Elimnate code overhead

### DIFF
--- a/puree/src/main/java/com/cookpad/puree/internal/LogDumper.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/LogDumper.java
@@ -23,8 +23,9 @@ public class LogDumper {
                         + records.getJsonLogs().get(0));
             default:
                 StringBuilder builder = new StringBuilder();
-                builder.append(records.size() + " records in Puree's buffer\n");
-                for (int i = 0; i < records.size(); i++) {
+                int size = records.size();
+                builder.append(size).append(" records in Puree's buffer\n");
+                for (int i = 0; i < size; i++) {
                     builder.append(records.getJsonLogs().get(0)).append("\n");
                 }
                 Log.d(TAG, builder.substring(0, builder.length() - 1));


### PR DESCRIPTION
* We use `StringBuilder#append` for String concat instead of `String#+`.
* We avoid a method call in for loop (every loop) so call a method call once.
 
  In every loop
  records.size() -> Class lookup -> Method table lookup -> Jump

There is avoiding method call in for loop in the following presentation.
Eliminating Code Overhead
https://speakerdeck.com/jakewharton/eliminating-code-overhead-square-hq-2015