### PR TITLE
Use scheduled executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Configure Puree with `PureeConfiguration` in `Application#onCreate()`, which reg
 pairs of what and where.
 
 ```java
-public class DemoApplication extends Application {
+public class MyApplication extends Application {
     @Override
     public void onCreate() {
         Puree.initialize(buildConfiguration(this));
@@ -51,12 +51,15 @@ public class DemoApplication extends Application {
     public static PureeConfiguration buildConfiguration(Context context) {
         PureeFilter addEventTimeFilter = new AddEventTimeFilter();
         return new PureeConfiguration.Builder(context)
+                .executor(Executors.newScheduledThreadPool(1)) // optional
                 .register(ClickLog.class, new OutLogcat())
                 .register(ClickLog.class, new OutBufferedLogcat().withFilters(addEventTimeListener))
                 .build();
     }
 }
 ```
+
+See also: [demo/PureeConfigurator.java](demo/src/main/java/com/example/puree/logs/PureeConfigurator.java)
 
 ### Definition of PureeLog objects
 

--- a/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
+++ b/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
@@ -12,6 +12,8 @@ import com.example.puree.logs.plugins.OutDisplay;
 
 import android.content.Context;
 
+import java.util.concurrent.Executors;
+
 public class PureeConfigurator {
     public static void configure(Context context) {
         Puree.initialize(buildConf(context));
@@ -21,6 +23,7 @@ public class PureeConfigurator {
         PureeFilter addEventTimeFilter = new AddEventTimeFilter();
         PureeFilter samplingFilter = new SamplingFilter(1.0f);
         PureeConfiguration conf = new PureeConfiguration.Builder(context)
+                .executor(Executors.newScheduledThreadPool(1)) // optional
                 .register(ClickLog.class, new OutDisplay().withFilters(addEventTimeFilter))
                 .register(ClickLog.class,
                         new OutBufferedLogcat().withFilters(addEventTimeFilter, samplingFilter))

--- a/demo/src/main/java/com/example/puree/logs/plugins/OutFakeApi.java
+++ b/demo/src/main/java/com/example/puree/logs/plugins/OutFakeApi.java
@@ -25,7 +25,8 @@ public class OutFakeApi extends PureeBufferedOutput {
         // you can change settings of this plugin
         conf.setFlushIntervalMillis(1000); // set interval of sending logs. defaults to 2 * 60 * 1000 (2 minutes).
         conf.setLogsPerRequest(10);        // set num of logs per request. defaults to 100.
-        conf.setMaxRetryCount(3);          // set retry count. if fail to send logs, logs will be sending at next time. defaults to 5.
+        conf.setMaxRetryCount(
+                3);          // set retry count. if fail to send logs, logs will be sending at next timeInMillis. defaults to 5.
         return conf;
     }
 

--- a/puree/src/androidTest/java/com/cookpad/puree/PureeTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/PureeTest.java
@@ -21,7 +21,7 @@ public class PureeTest {
 
         public DummyPureeLogger(Context context) {
             super(new HashMap<Class<?>, List<PureeOutput>>(), new Gson(), new PureeSQLiteStorage(context),
-                    Executors.newSingleThreadExecutor());
+                    Executors.newScheduledThreadPool(1));
         }
 
 
@@ -33,6 +33,7 @@ public class PureeTest {
 
     static class PvLog implements PureeLog {
 
+        @SuppressWarnings("unused")
         String name = "foo";
     }
 

--- a/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeBufferedOutputTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeBufferedOutputTest.java
@@ -17,8 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 import android.support.test.InstrumentationRegistry;
 
 import java.util.concurrent.ArrayBlockingQueue;
@@ -29,14 +27,12 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
 public class PureeBufferedOutputTest {
 
     Context context;
-
-    Handler handler;
 
     BlockingQueue<String> logs = new ArrayBlockingQueue<>(3);
 
@@ -53,10 +49,6 @@ public class PureeBufferedOutputTest {
 
     @ParametersAreNonnullByDefault
     static abstract class BufferedOutputBase extends PureeBufferedOutput {
-
-        public BufferedOutputBase(Handler handler) {
-            super(handler);
-        }
 
         @Nonnull
         @Override
@@ -75,10 +67,6 @@ public class PureeBufferedOutputTest {
     @ParametersAreNonnullByDefault
     class BufferedOutput extends BufferedOutputBase {
 
-        public BufferedOutput(Handler handler) {
-            super(handler);
-        }
-
         @Override
         public void emit(JsonArray jsonArray, AsyncResult result) {
             for (JsonElement item : jsonArray) {
@@ -91,10 +79,6 @@ public class PureeBufferedOutputTest {
     @ParametersAreNonnullByDefault
     class DiscardedBufferedOutput extends BufferedOutputBase {
 
-        public DiscardedBufferedOutput(Handler handler) {
-            super(handler);
-        }
-
         @Override
         public void emit(JsonArray jsonArray, AsyncResult result) {
             throw new AssertionFailedError("not reached");
@@ -105,10 +89,6 @@ public class PureeBufferedOutputTest {
     class BufferedOutputToTestFailFirst extends BufferedOutputBase {
 
         int counter = 0;
-
-        public BufferedOutputToTestFailFirst(Handler handler) {
-            super(handler);
-        }
 
         @Override
         public void emit(JsonArray jsonArray, AsyncResult result) {
@@ -137,7 +117,6 @@ public class PureeBufferedOutputTest {
     @Before
     public void setUp() throws Exception {
         context = InstrumentationRegistry.getTargetContext();
-        handler = new Handler(Looper.getMainLooper());
     }
 
     @After
@@ -157,7 +136,7 @@ public class PureeBufferedOutputTest {
 
     @Test
     public void testPureeBufferedOutput() throws Exception {
-        initializeLogger(new BufferedOutput(handler));
+        initializeLogger(new BufferedOutput());
 
         logger.send(new PvLog("foo"));
         logger.send(new PvLog("bar"));
@@ -174,7 +153,7 @@ public class PureeBufferedOutputTest {
 
     @Test
     public void testPureeBufferedOutputWithDiscardFilter() throws Exception {
-        initializeLogger(new DiscardedBufferedOutput(handler).withFilters(new DiscardFilter()));
+        initializeLogger(new DiscardedBufferedOutput().withFilters(new DiscardFilter()));
 
         logger.send(new PvLog("foo"));
         logger.send(new PvLog("bar"));
@@ -188,7 +167,7 @@ public class PureeBufferedOutputTest {
 
     @Test
     public void testBufferedOutputToTestFailFirst() throws Exception {
-        BufferedOutputToTestFailFirst output = new BufferedOutputToTestFailFirst(handler);
+        BufferedOutputToTestFailFirst output = new BufferedOutputToTestFailFirst();
         initializeLogger(output);
 
         logger.send(new PvLog("foo"));

--- a/puree/src/androidTest/java/com/cookpad/puree/retryable/BackoffCounterTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/retryable/BackoffCounterTest.java
@@ -17,27 +17,27 @@ public class BackoffCounterTest {
         BackoffCounter backoffCounter = new BackoffCounter(10, 3);
 
         assertThat(backoffCounter.getRetryCount(), is(0));
-        assertThat(backoffCounter.time(), is(10));
+        assertThat(backoffCounter.timeInMillis(), is(10L));
         assertThat(backoffCounter.isRemainingRetryCount(), is(true));
 
         backoffCounter.incrementRetryCount();
         assertThat(backoffCounter.getRetryCount(), is(1));
-        assertThat(backoffCounter.time(), is(20));
+        assertThat(backoffCounter.timeInMillis(), is(20L));
         assertThat(backoffCounter.isRemainingRetryCount(), is(true));
 
         backoffCounter.incrementRetryCount();
         assertThat(backoffCounter.getRetryCount(), is(2));
-        assertThat(backoffCounter.time(), is(30));
+        assertThat(backoffCounter.timeInMillis(), is(30L));
         assertThat(backoffCounter.isRemainingRetryCount(), is(true));
 
         backoffCounter.incrementRetryCount();
         assertThat(backoffCounter.getRetryCount(), is(3));
-        assertThat(backoffCounter.time(), is(40));
+        assertThat(backoffCounter.timeInMillis(), is(40L));
         assertThat(backoffCounter.isRemainingRetryCount(), is(false));
 
         backoffCounter.resetRetryCount();
         assertThat(backoffCounter.getRetryCount(), is(0));
-        assertThat(backoffCounter.time(), is(10));
+        assertThat(backoffCounter.timeInMillis(), is(10L));
         assertThat(backoffCounter.isRemainingRetryCount(), is(true));
     }
 }

--- a/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
@@ -21,7 +21,7 @@ public class RetryableTaskRunnerTest {
     private ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
     @Test
-    public void ensureToCallMeAfterSetTime() throws Exception {
+    public void testEnsureToCallMeAfterSetTime() throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
 
         RetryableTaskRunner task = new RetryableTaskRunner(new Runnable() {
@@ -33,6 +33,27 @@ public class RetryableTaskRunnerTest {
 
         task.tryToStart();
 
-        assertThat(latch.await(30, TimeUnit.MILLISECONDS), is(true));
+        assertThat(latch.await(20, TimeUnit.MILLISECONDS), is(true));
     }
+
+    @Test
+    public void testRetryLater() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(2);
+
+        RetryableTaskRunner task = new RetryableTaskRunner(new Runnable() {
+            @Override
+            public void run() {
+                latch.countDown();
+            }
+        }, 10, 5, executor);
+
+        task.tryToStart();
+
+        assertThat(latch.await(20, TimeUnit.MILLISECONDS), is(false));
+
+        task.retryLater();
+
+        assertThat(latch.await(20, TimeUnit.MILLISECONDS), is(true));
+    }
+
 }

--- a/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
@@ -53,6 +53,8 @@ public class RetryableTaskRunnerTest {
 
         task.retryLater();
 
-        assertThat(latch.await(20, TimeUnit.MILLISECONDS), is(true));
+        assertThat(latch.await(40, TimeUnit.MILLISECONDS), is(true));
+
+        assertThat(latch.getCount(), is(0L));
     }
 }

--- a/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
@@ -2,15 +2,14 @@ package com.cookpad.puree.retryable;
 
 import com.cookpad.puree.internal.RetryableTaskRunner;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import android.os.Handler;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.*;
@@ -19,17 +18,7 @@ import static org.junit.Assert.*;
 @RunWith(AndroidJUnit4.class)
 public class RetryableTaskRunnerTest {
 
-    private Handler handler;
-
-    @Before
-    public void setUp() throws Exception {
-        InstrumentationRegistry.getInstrumentation().runOnMainSync(new Runnable() {
-            @Override
-            public void run() {
-                handler = new Handler();
-            }
-        });
-    }
+    private ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 
     @Test
     public void ensureToCallMeAfterSetTime() throws Exception {
@@ -40,7 +29,7 @@ public class RetryableTaskRunnerTest {
             public void run() {
                 latch.countDown();
             }
-        }, 10, 5, handler);
+        }, 10, 5, executor);
 
         task.tryToStart();
 

--- a/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/retryable/RetryableTaskRunnerTest.java
@@ -55,5 +55,4 @@ public class RetryableTaskRunnerTest {
 
         assertThat(latch.await(20, TimeUnit.MILLISECONDS), is(true));
     }
-
 }

--- a/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
+++ b/puree/src/main/java/com/cookpad/puree/PureeConfiguration.java
@@ -13,8 +13,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -30,7 +30,7 @@ public class PureeConfiguration {
 
     private final PureeStorage storage;
 
-    private final Executor executor;
+    private final ScheduledExecutorService executor;
 
     public Context getContext() {
         return context;
@@ -57,7 +57,7 @@ public class PureeConfiguration {
     }
 
     PureeConfiguration(Context context, Gson gson, Map<Class<?>, List<PureeOutput>> sourceOutputMap, PureeStorage storage,
-            Executor executor) {
+            ScheduledExecutorService executor) {
         this.context = context;
         this.gson = gson;
         this.sourceOutputMap = sourceOutputMap;
@@ -81,7 +81,7 @@ public class PureeConfiguration {
 
         private PureeStorage storage;
 
-        private Executor executor;
+        private ScheduledExecutorService executor;
 
         /**
          * Start building a new {@link com.cookpad.puree.PureeConfiguration} instance.
@@ -121,7 +121,7 @@ public class PureeConfiguration {
             return this;
         }
 
-        public Builder executor(Executor executor) {
+        public Builder executor(ScheduledExecutorService executor) {
             this.executor = executor;
             return this;
         }
@@ -137,14 +137,14 @@ public class PureeConfiguration {
                 storage = new PureeSQLiteStorage(context);
             }
             if (executor == null) {
-                executor = newBackgroundThradExecutor();
+                executor = newBackgroundExecutor();
             }
             return new PureeConfiguration(context, gson, sourceOutputMap, storage, executor);
         }
     }
 
-    static Executor newBackgroundThradExecutor() {
-        return Executors.newSingleThreadExecutor(new BackgroundThreadFactory());
+    static ScheduledExecutorService newBackgroundExecutor() {
+        return Executors.newScheduledThreadPool(1, new BackgroundThreadFactory());
     }
 
     static class BackgroundThreadFactory implements ThreadFactory {

--- a/puree/src/main/java/com/cookpad/puree/PureeLogger.java
+++ b/puree/src/main/java/com/cookpad/puree/PureeLogger.java
@@ -10,7 +10,7 @@ import com.cookpad.puree.storage.Records;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -24,9 +24,10 @@ public class PureeLogger {
 
     final PureeStorage storage;
 
-    final Executor executor;
+    final ScheduledExecutorService executor;
 
-    public PureeLogger(Map<Class<?>, List<PureeOutput>> sourceOutputMap, Gson gson, PureeStorage storage, Executor executor) {
+    public PureeLogger(Map<Class<?>, List<PureeOutput>> sourceOutputMap, Gson gson, PureeStorage storage,
+            ScheduledExecutorService executor) {
         this.sourceOutputMap.putAll(sourceOutputMap);
         this.gson = gson;
         this.storage = storage;
@@ -35,7 +36,7 @@ public class PureeLogger {
         forEachOutput(new PureeLogger.Consumer<PureeOutput>() {
             @Override
             public void accept(@Nonnull PureeOutput value) {
-                value.initialize(PureeLogger.this.storage);
+                value.initialize(PureeLogger.this);
             }
         });
     }
@@ -48,7 +49,11 @@ public class PureeLogger {
         }
     }
 
-    public Executor getExecutor() {
+    public PureeStorage getStorage() {
+        return storage;
+    }
+
+    public ScheduledExecutorService getExecutor() {
         return executor;
     }
 

--- a/puree/src/main/java/com/cookpad/puree/internal/BackoffCounter.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/BackoffCounter.java
@@ -29,7 +29,7 @@ public class BackoffCounter {
         retryCount = 0;
     }
 
-    public int time() {
+    public long timeInMillis() {
         if (retryCount == 0) {
             return baseTimeMillis;
         } else {

--- a/puree/src/main/java/com/cookpad/puree/internal/RetryableTaskRunner.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/RetryableTaskRunner.java
@@ -1,32 +1,27 @@
 package com.cookpad.puree.internal;
 
-import android.os.Handler;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 public class RetryableTaskRunner {
 
-    private Handler handler;
-
     private boolean hasAlreadyStarted;
 
-    private Runnable callback;
+    private Runnable task;
 
     private BackoffCounter backoffCounter;
 
-    public RetryableTaskRunner(final Runnable task, int intervalMillis, int maxRetryCount) {
-        this(task, intervalMillis, maxRetryCount, new Handler());
-    }
+    private ScheduledExecutorService executor;
 
-    public RetryableTaskRunner(final Runnable task, int intervalMillis, int maxRetryCount, Handler handler) {
+    private ScheduledFuture<?> future;
+
+    public RetryableTaskRunner(final Runnable task, int intervalMillis, int maxRetryCount, ScheduledExecutorService executor) {
         this.backoffCounter = new BackoffCounter(intervalMillis, maxRetryCount);
-        this.handler = handler;
+        this.executor = executor;
         this.hasAlreadyStarted = false;
 
-        this.callback = new Runnable() {
-            @Override
-            public void run() {
-                task.run();
-            }
-        };
+        this.task = task;
     }
 
     public synchronized void tryToStart() {
@@ -38,8 +33,7 @@ public class RetryableTaskRunner {
     }
 
     private synchronized void startDelayed() {
-        handler.removeCallbacks(callback);
-        handler.postDelayed(callback, backoffCounter.time());
+        future = executor.schedule(task, backoffCounter.timeInMillis(), TimeUnit.MILLISECONDS);
         hasAlreadyStarted = true;
     }
 

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeOutput.java
@@ -3,6 +3,7 @@ package com.cookpad.puree.outputs;
 import com.google.gson.JsonObject;
 
 import com.cookpad.puree.PureeFilter;
+import com.cookpad.puree.PureeLogger;
 import com.cookpad.puree.storage.PureeStorage;
 
 import java.util.ArrayList;
@@ -39,8 +40,8 @@ public abstract class PureeOutput {
         return filters;
     }
 
-    public void initialize(PureeStorage storage) {
-        this.storage = storage;
+    public void initialize(PureeLogger logger) {
+        this.storage = logger.getStorage();
         OutputConfiguration defaultConfiguration = new OutputConfiguration();
         this.conf = configure(defaultConfiguration);
     }


### PR DESCRIPTION
Use `ScheduledExecutorService` instead of `Handler` to run tasks with delays.

This PR eliminates AsyncTask and use a specific executor service to run tasks in background.

Related PR: https://github.com/cookpad/puree-android/pull/44