### PR TITLE
Output errors during execution of BufferedOutput

### DIFF
--- a/puree/src/main/java/com/cookpad/puree/internal/PureeVerboseRunnable.java
+++ b/puree/src/main/java/com/cookpad/puree/internal/PureeVerboseRunnable.java
@@ -1,0 +1,27 @@
+package com.cookpad.puree.internal;
+
+import android.util.Log;
+
+import javax.annotation.Nonnull;
+
+public final class PureeVerboseRunnable implements Runnable {
+    private static final String TAG = PureeVerboseRunnable.class.getSimpleName();
+
+    private final Runnable task;
+
+    public PureeVerboseRunnable(@Nonnull final Runnable task) {
+        this.task = task;
+    }
+
+    public void run() {
+        try {
+            this.task.run();
+        } catch (RuntimeException ex) {
+            Log.e(TAG, "Puree detected an uncaught runtime exception while executing", ex);
+            throw ex;
+        } catch (Error error) {
+            Log.e(TAG, "Puree detected an uncaught error while executing", error);
+            throw error;
+        }
+    }
+}

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
@@ -1,5 +1,6 @@
 package com.cookpad.puree.outputs;
 
+import com.cookpad.puree.internal.PureeVerboseRunnable;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
@@ -36,7 +37,7 @@ public abstract class PureeBufferedOutput extends PureeOutput {
 
     @Override
     public void receive(final JsonObject jsonLog) {
-        executor.execute(new Runnable() {
+        executor.execute(new PureeVerboseRunnable(new Runnable() {
             @Override
             public void run() {
                 JsonObject filteredLog = applyFilters(jsonLog);
@@ -44,19 +45,19 @@ public abstract class PureeBufferedOutput extends PureeOutput {
                     storage.insert(type(), filteredLog);
                 }
             }
-        });
+        }));
 
         flushTask.tryToStart();
     }
 
     @Override
     public void flush() {
-        executor.execute(new Runnable() {
+        executor.execute(new PureeVerboseRunnable(new Runnable() {
             @Override
             public void run() {
                 flushSync();
             }
-        });
+        }));
     }
 
     public void flushSync() {


### PR DESCRIPTION
A wrapper for Runnables that will log errors into logcat at error level. As ExecutorService#execute mutes Exceptions thrown there, this change will help developers easily spot errors on their filters and emitters.