### PR TITLE
use Robolectric-Instrumentation; now `./gradlew testDebug` works

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.1'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -69,11 +69,15 @@ android.libraryVariants.all { variant ->
 }
 
 dependencies {
-    compile 'com.google.code.gson:gson:2.3.1'
-    compile 'com.google.code.findbugs:jsr305:3.0.0'
+    compile 'com.google.code.gson:gson:2.4'
+    compile 'com.google.code.findbugs:jsr305:3.0.1'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
-    androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
+    androidTestCompile 'com.android.support.test:runner:0.4.1'
+    androidTestCompile 'junit:junit:4.12'
+    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
+    testCompile 'com.github.gfx.android.robolectricinstrumentation:robolectric-instrumentation:3.0.6'
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.hamcrest:hamcrest-library:1.3'
 }
 
 task androidJar(type: Jar) {

--- a/puree/src/androidTest/java/com/cookpad/puree/PureeTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/PureeTest.java
@@ -7,14 +7,17 @@ import com.cookpad.puree.storage.PureeSQLiteStorage;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.Executors;
 
+@RunWith(AndroidJUnit4.class)
 public class PureeTest {
 
     static class DummyPureeLogger extends PureeLogger {

--- a/puree/src/androidTest/java/com/cookpad/puree/internal/LogDumperTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/internal/LogDumperTest.java
@@ -4,10 +4,14 @@ import com.cookpad.puree.outputs.PureeOutput;
 import com.cookpad.puree.storage.Records;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.test.runner.AndroidJUnit4;
 
 import java.util.HashMap;
 import java.util.List;
 
+@RunWith(AndroidJUnit4.class)
 public class LogDumperTest {
 
     @Test

--- a/puree/src/androidTest/java/com/cookpad/puree/internal/ProcessNameTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/internal/ProcessNameTest.java
@@ -2,14 +2,22 @@ package com.cookpad.puree.internal;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assume.assumeTrue;
 
+@RunWith(AndroidJUnit4.class)
 public class ProcessNameTest {
+
+    boolean runOnAndroid() {
+        return System.getProperty("java.vm.name").equals("Dalvik");
+    }
 
     Context context;
 
@@ -25,11 +33,15 @@ public class ProcessNameTest {
 
     @Test
     public void testFindProcessNameInLinuxWay() throws Exception {
+        assumeTrue(runOnAndroid());
+
         assertThat(ProcessName.findProcessNameInLinuxWay(), is("com.cookpad.android.puree.test"));
     }
 
     @Test
     public void testFindProcessNameInAndroidWay() throws Exception {
+        assumeTrue(runOnAndroid());
+
         assertThat(ProcessName.findProcessNameInAndroidWay(context), is("com.cookpad.android.puree.test"));
     }
 

--- a/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeBufferedOutputTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeBufferedOutputTest.java
@@ -15,9 +15,11 @@ import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -30,6 +32,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
 
+@RunWith(AndroidJUnit4.class)
 public class PureeBufferedOutputTest {
 
     Context context;

--- a/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeOutputTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeOutputTest.java
@@ -6,6 +6,9 @@ import com.cookpad.puree.PureeFilter;
 
 import org.json.JSONException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.test.runner.AndroidJUnit4;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -14,6 +17,7 @@ import javax.annotation.Nonnull;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+@RunWith(AndroidJUnit4.class)
 public class PureeOutputTest {
     @Test
     public void discardLog() {

--- a/puree/src/androidTest/resources/robolectric.properties
+++ b/puree/src/androidTest/resources/robolectric.properties
@@ -1,0 +1,3 @@
+project=puree
+sdk=16
+constants=com.cookpad.android.puree.BuildConfig

--- a/puree/src/test
+++ b/puree/src/test
@@ -1,0 +1,1 @@
+androidTest


### PR DESCRIPTION
Most of tests works both with Robolectric and Android Instrumentation without logic changes.

Only `ProcessName` does not work on JVM, so I've disable its tests on JVM.