### PR TITLE
Integrate PureeSQLiteStorage with androidx.sqlite

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -2,6 +2,7 @@
 object Libs {
     const val appCompatV7 = "com.android.support:appcompat-v7:28.0.0"
 
+    const val sqlite = "androidx.sqlite:sqlite-framework:2.0.1"
     const val gson = "com.google.code.gson:gson:2.8.2"
     const val jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 }

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -71,6 +71,7 @@ android.libraryVariants.all { variant ->
 }
 
 dependencies {
+    api Libs.sqlite
     api Libs.gson
     implementation Libs.jsr305
 


### PR DESCRIPTION
## Integrate PureeSQLiteStorage with AndroidX SQLite

This PR is just a proposal. If you can not accept, please feel free to close this.

### Why

AndroidX provides SQLite support library. This library handles the framework's SQLite database well.
I think it is more reliable than using `SQLiteOpenHelper` directly.

### Reference

I referenced [implementation of AndroidX Room](https://github.com/aosp-mirror/platform_frameworks_support/blob/3d7e8b9a8f94b78d296a4f98860d1ffc9e61dda7/room/runtime/src/main/java/androidx/room/RoomDatabase.java#L302-L306) and JavaDoc of [SupportSQLiteOpenHelper](https://github.com/aosp-mirror/platform_frameworks_support/blob/3d7e8b9a8f94b78d296a4f98860d1ffc9e61dda7/persistence/db/src/main/java/androidx/sqlite/db/SupportSQLiteOpenHelper.java#L67-L71).
It calls `getWritableDatabase` every query execution instead of keeping a reference of the database instance.
Also, it has followed it in this implementation.
