### PR TITLE
Fix empty jar artifact publishing

### DIFF
--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -87,10 +87,6 @@ dependencies {
     androidTestImplementation TestLibs.androidXTestJUnit
 }
 
-task androidJar(type: Jar) {
-    from 'build/intermediates/classes/release'
-}
-
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.java.srcDirs
@@ -102,7 +98,6 @@ task androidJavadocJar(type: Jar) {
 }
 
 artifacts {
-    archives androidJar
     archives androidSourcesJar
     archives androidJavadocJar
 }
@@ -113,7 +108,7 @@ publishing {
             groupId GROUP_ID
             artifactId ARTIFACT_ID
             version VERSION
-            artifact androidJar
+            artifact bundleReleaseAar
             artifact androidSourcesJar
             artifact androidJavadocJar
             pom.withXml {


### PR DESCRIPTION
fix #68

To fix empty jar artifact, I changed maven publishing configuration to use outputted AAR file directly.
I can't verify upload result, but I've checked local maven repo installed by executing `./gradlew clean puree:publishToMavenLocal`.

Results is below

**Before**
```
com/cookpad/puree
└── puree
    ├── 4.1.3
    │   ├── puree-4.1.3-javadoc.jar
    │   ├── puree-4.1.3-sources.jar
    │   ├── puree-4.1.3.jar
    │   │   └── META-INF
    │   │       └── MANIFEST.MF
    │   └── puree-4.1.3.pom
    └── maven-metadata-local.xml
```

**After**
```
com/cookpad/puree
└── puree
    ├── 4.1.3
    │   ├── puree-4.1.3-javadoc.jar
    │   ├── puree-4.1.3-sources.jar
    │   ├── puree-4.1.3.aar
    │   │   ├── AndroidManifest.xml
    │   │   ├── R.txt
    │   │   └── classes.jar
    │   │       └── com
    │   │           └── cookpad
    │   │               ├── android
    │   │               │   └── puree
    │   │               │       └── BuildConfig.class
    │   │               └── puree
    │   │                   ├── Puree$NotInitializedException.class
    │   │                   ├── Puree.class
    │   │                   ├── PureeConfiguration$BackgroundThreadFactory.class
    │   │                   ├── PureeConfiguration$Builder.class
    │   │                   ├── PureeConfiguration.class
    │   │                   ├── PureeFilter.class
    │   │                   ├── PureeLog.class
    │   │                   ├── PureeLogger$1.class
    │   │                   ├── PureeLogger$2.class
    │   │                   ├── PureeLogger$Consumer.class
    │   │                   ├── PureeLogger$NoRegisteredOutputPluginException.class
    │   │                   ├── PureeLogger.class
    │   │                   ├── Source.class
    │   │                   ├── async
    │   │                   │   └── AsyncResult.class
    │   │                   ├── internal
    │   │                   │   ├── BackoffCounter.class
    │   │                   │   ├── LogDumper.class
    │   │                   │   ├── ProcessName.class
    │   │                   │   ├── PureeVerboseRunnable.class
    │   │                   │   └── RetryableTaskRunner.class
    │   │                   ├── outputs
    │   │                   │   ├── OutputConfiguration.class
    │   │                   │   ├── PureeBufferedOutput$1.class
    │   │                   │   ├── PureeBufferedOutput$2.class
    │   │                   │   ├── PureeBufferedOutput$3.class
    │   │                   │   ├── PureeBufferedOutput$4.class
    │   │                   │   ├── PureeBufferedOutput.class
    │   │                   │   └── PureeOutput.class
    │   │                   └── storage
    │   │                       ├── PureeSQLiteStorage.class
    │   │                       ├── PureeStorage.class
    │   │                       ├── Record.class
    │   │                       └── Records.class
    │   └── puree-4.1.3.pom
    └── maven-metadata-local.xml
```