### PR TITLE
Bump up to 4.1.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# v4.1.4 2019/06/20
+# v4.1.5 2019/06/21
 
 * Fix classes.jar path to packaged-classes 
   - https://github.com/cookpad/puree-android/pull/70

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ buildscript {
 
 // app/build.gradle
 dependencies {
-    compile 'com.cookpad.puree:puree:4.1.4'
+    compile 'com.cookpad.puree:puree:4.1.5'
 }
 ```
 
@@ -217,8 +217,8 @@ bintrayKey=BINTRAY_API_KEY
 and run the following tasks:
 
 ```
-./gradlew clean connectedCheck bintrayUpload --info # dry-run
-./gradlew bintrayUpload -PdryRun=false
+./gradlew clean connectedCheck assembleRelease bintrayUpload --info # dry-run
+./gradlew assembleRelease bintrayUpload -PdryRun=false
 ```
 
 # See Also

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.jfrog.bintray'
 
 def GROUP_ID = 'com.cookpad.puree'
 def ARTIFACT_ID = 'puree'
-def VERSION = "4.1.4"
+def VERSION = "4.1.5"
 
 project.version = VERSION
 println "building ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"


### PR DESCRIPTION
デプロイ作業がミスっていたため`v4.1.4`と同じ内容で`v4.1.5`をリリースします