### PR TITLE
Include dependencies in pom

### DIFF
--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -132,6 +132,14 @@ publishing {
                 license.appendNode('url',
                         'https://raw.githubusercontent.com/cookpad/puree-android/master/LICENSE.txt')
                 license.appendNode('distribution', 'repo')
+                def dependencies = root.appendNode('dependencies')
+                configurations.api.allDependencies.each { dependency ->
+                    def dependencyNode = dependencies.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', dependency.group)
+                    dependencyNode.appendNode('artifactId', dependency.name)
+                    dependencyNode.appendNode('version', dependency.version)
+                    dependencyNode.appendNode('scope', "compile")
+                }
             }
         }
     }


### PR DESCRIPTION
I think it should include all required dependencies so that users only need to depend on puree-android, so how about include dependencies in pom?

refs. https://github.com/cookpad/puree-android/pull/67