### PR TITLE
Remove android:allowBackup attribution

### DIFF
--- a/puree/src/main/AndroidManifest.xml
+++ b/puree/src/main/AndroidManifest.xml
@@ -1,5 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.cookpad.android.puree">
-
-    <application android:allowBackup="true" />
-</manifest>
+<manifest package="com.cookpad.android.puree" />


### PR DESCRIPTION
`android:allowBackup="true"` attribute cause build error below on app side if the app doesn't allow backup.
The app can fix the error with `tools:replace="android:allowBackup"`, but I think that allowBackup attribute is not necessary for this library side.

```
Execution failed for task ':app:processDebugManifest'.
> Manifest merger failed : Attribute application@allowBackup value=(false) from AndroidManifest.xml:27:9-36
  	is also present at [com.cookpad.puree:puree:4.1.6] AndroidManifest.xml:11:18-44 value=(true).
  	Suggestion: add 'tools:replace="android:allowBackup"' to <application> element at AndroidManifest.xml:6:5-16:19 to override.
```