### PR TITLE
Allow purging of old buffered logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,32 @@ new PureeConfiguration.Builder(context)
         .build();
 ```
 
+### Purging old logs
+To discard unnecessary recorded logs, purge age can be configured in the PureeBufferedOutput subclass.
+
+```java
+public class OutPurge extends PureeBufferedOutput {
+
+    // ..
+
+    @Override
+    public OutputConfiguration configure(OutputConfiguration conf) {
+        // set to purge buffered logs older than 2 weeks
+        conf.setPurgeAgeMillis(2 * 7 * 24 * 60 * 60 * 1000);
+        return conf;
+    }
+}
+```
+
+The configured storage must be an instance of `PureeSQLiteStorage` or a subclass of it to support purging of old logs.
+
+```java
+new PureeConfiguration.Builder(context)
+        .storage(new PureeSQLiteStorage(context))
+        .register(ClickLog.class, new OutPurge().withFilters(addEventTimeFilter, samplingFilter)
+        .build();
+```
+
 ## Testing
 
 If you want to mock or ignore `Puree.send()` and `Puree.flush()`, you can use `Puree.setPureeLogger()` to replace the internal

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ public class OutPurge extends PureeBufferedOutput {
 }
 ```
 
-The configured storage must be an instance of `PureeSQLiteStorage` or a subclass of it to support purging of old logs.
+The configured storage must extend `EnhancedPureeStorage` to support purging of old logs. The default `PureeSQLiteStorage` can be used to enable this feature.
 
 ```java
 new PureeConfiguration.Builder(context)

--- a/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
+++ b/demo/src/main/java/com/example/puree/logs/PureeConfigurator.java
@@ -3,10 +3,10 @@ package com.example.puree.logs;
 import com.cookpad.puree.Puree;
 import com.cookpad.puree.PureeConfiguration;
 import com.cookpad.puree.PureeFilter;
-import com.cookpad.puree.plugins.OutBufferedLogcat;
 import com.cookpad.puree.plugins.OutLogcat;
 import com.example.puree.AddEventTimeFilter;
 import com.example.puree.logs.filters.SamplingFilter;
+import com.example.puree.logs.plugins.OutBufferedLogcatPurge;
 import com.example.puree.logs.plugins.OutBufferedVoid;
 import com.example.puree.logs.plugins.OutDisplay;
 
@@ -27,7 +27,7 @@ public class PureeConfigurator {
                 .executor(Executors.newScheduledThreadPool(1)) // optional
                 .register(ClickLog.class, new OutDisplay().withFilters(addEventTimeFilter))
                 .register(ClickLog.class,
-                        new OutBufferedLogcat().withFilters(addEventTimeFilter, samplingFilter))
+                        new OutBufferedLogcatPurge().withFilters(addEventTimeFilter, samplingFilter))
                 .register(PvLog.class, new OutLogcat().withFilters(addEventTimeFilter))
                 .register(BenchmarkLog.class, new OutBufferedVoid().withFilters(addEventTimeFilter))
                 .build();

--- a/demo/src/main/java/com/example/puree/logs/plugins/OutBufferedLogcatPurge.java
+++ b/demo/src/main/java/com/example/puree/logs/plugins/OutBufferedLogcatPurge.java
@@ -1,0 +1,18 @@
+package com.example.puree.logs.plugins;
+
+import com.cookpad.puree.outputs.OutputConfiguration;
+import com.cookpad.puree.plugins.OutBufferedLogcat;
+
+import javax.annotation.Nonnull;
+
+public class OutBufferedLogcatPurge extends OutBufferedLogcat {
+
+    @Nonnull
+    @Override
+    public OutputConfiguration configure(OutputConfiguration conf) {
+        conf = super.configure(conf);
+        conf.setFlushIntervalMillis(1000);
+        conf.setPurgeAgeMillis(5000);
+        return conf;
+    }
+}

--- a/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeBufferedOutputTest.java
+++ b/puree/src/androidTest/java/com/cookpad/puree/outputs/PureeBufferedOutputTest.java
@@ -166,6 +166,16 @@ public class PureeBufferedOutputTest {
         }
     }
 
+    class BufferedOutputPurge extends BufferedOutput{
+
+        @Nonnull
+        @Override
+        public OutputConfiguration configure(OutputConfiguration conf) {
+            conf.setPurgeAgeMillis(1000);
+            return conf;
+        }
+    }
+
     @Before
     public void setUp() throws Exception {
         context = ApplicationProvider.getApplicationContext();
@@ -362,4 +372,20 @@ public class PureeBufferedOutputTest {
 
     }
 
+    @Test
+    public void testPureeBufferedOutput_purge() throws Exception {
+        initializeLogger(new BufferedOutputPurge());
+        logger.discardBufferedLogs();
+
+        logger.send(new PvLog("foo"));
+        Thread.sleep(1000);
+        logger.send(new PvLog("bar"));
+        Thread.sleep(900);
+        logger.send(new PvLog("baz"));
+
+        logger.flush();
+
+        assertThat(logs.poll(100, TimeUnit.MILLISECONDS), is("{\"name\":\"bar\"}"));
+        assertThat(logs.poll(100, TimeUnit.MILLISECONDS), is("{\"name\":\"baz\"}"));
+    }
 }

--- a/puree/src/main/java/com/cookpad/puree/outputs/OutputConfiguration.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/OutputConfiguration.java
@@ -7,6 +7,7 @@ public class OutputConfiguration {
     private int flushIntervalMillis = 2 * 60 * 1000; // 2 minutes
     private int logsPerRequest = 100;
     private int maxRetryCount = 5;
+    private long purgeAgeMillis = -1;
 
     OutputConfiguration() {
     }
@@ -33,5 +34,13 @@ public class OutputConfiguration {
 
     public void setMaxRetryCount(int maxRetryCount) {
         this.maxRetryCount = maxRetryCount;
+    }
+
+    public long getPurgeAgeMillis() {
+        return purgeAgeMillis;
+    }
+
+    public void setPurgeAgeMillis(long purgeAgeMillis) {
+        this.purgeAgeMillis = purgeAgeMillis;
     }
 }

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
@@ -4,6 +4,7 @@ import com.cookpad.puree.PureeLogger;
 import com.cookpad.puree.async.AsyncResult;
 import com.cookpad.puree.internal.PureeVerboseRunnable;
 import com.cookpad.puree.internal.RetryableTaskRunner;
+import com.cookpad.puree.storage.PureeSQLiteStorage;
 import com.cookpad.puree.storage.Records;
 
 import java.util.List;
@@ -63,6 +64,7 @@ public abstract class PureeBufferedOutput extends PureeOutput {
             flushTask.retryLater();
             return;
         }
+        purgeRecordsFromStorage();
         final Records records = getRecordsFromStorage();
 
         if (records.isEmpty()) {
@@ -94,6 +96,14 @@ public abstract class PureeBufferedOutput extends PureeOutput {
     }
 
     public abstract void emit(List<String> jsonLogs, final AsyncResult result);
+
+    private void purgeRecordsFromStorage() {
+        if (!(storage instanceof PureeSQLiteStorage) || conf.getPurgeAgeMillis() == -1) {
+            return;
+        }
+
+        ((PureeSQLiteStorage) storage).delete(type(), conf.getPurgeAgeMillis());
+    }
 
     public void emit(String jsonLog) {
         // do nothing

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
@@ -4,7 +4,7 @@ import com.cookpad.puree.PureeLogger;
 import com.cookpad.puree.async.AsyncResult;
 import com.cookpad.puree.internal.PureeVerboseRunnable;
 import com.cookpad.puree.internal.RetryableTaskRunner;
-import com.cookpad.puree.storage.PureeSQLiteStorage;
+import com.cookpad.puree.storage.EnhancedPureeStorage;
 import com.cookpad.puree.storage.Records;
 
 import java.util.List;
@@ -98,11 +98,11 @@ public abstract class PureeBufferedOutput extends PureeOutput {
     public abstract void emit(List<String> jsonLogs, final AsyncResult result);
 
     private void purgeRecordsFromStorage() {
-        if (!(storage instanceof PureeSQLiteStorage) || conf.getPurgeAgeMillis() == -1) {
+        if (!(storage instanceof EnhancedPureeStorage) || conf.getPurgeAgeMillis() == -1) {
             return;
         }
 
-        ((PureeSQLiteStorage) storage).delete(type(), conf.getPurgeAgeMillis());
+        ((EnhancedPureeStorage) storage).delete(type(), conf.getPurgeAgeMillis());
     }
 
     public void emit(String jsonLog) {

--- a/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
+++ b/puree/src/main/java/com/cookpad/puree/outputs/PureeBufferedOutput.java
@@ -98,7 +98,7 @@ public abstract class PureeBufferedOutput extends PureeOutput {
     public abstract void emit(List<String> jsonLogs, final AsyncResult result);
 
     private void purgeRecordsFromStorage() {
-        if (!(storage instanceof EnhancedPureeStorage) || conf.getPurgeAgeMillis() == -1) {
+        if (!(storage instanceof EnhancedPureeStorage) || conf.getPurgeAgeMillis() < 0) {
             return;
         }
 

--- a/puree/src/main/java/com/cookpad/puree/storage/EnhancedPureeStorage.java
+++ b/puree/src/main/java/com/cookpad/puree/storage/EnhancedPureeStorage.java
@@ -1,0 +1,7 @@
+package com.cookpad.puree.storage;
+
+public abstract class EnhancedPureeStorage implements PureeStorage {
+
+    public void delete(String type, long ageMillis) {
+    }
+}

--- a/puree/src/main/java/com/cookpad/puree/storage/PureeSQLiteStorage.java
+++ b/puree/src/main/java/com/cookpad/puree/storage/PureeSQLiteStorage.java
@@ -18,7 +18,7 @@ import androidx.sqlite.db.SupportSQLiteOpenHelper;
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 
 @ParametersAreNonnullByDefault
-public class PureeSQLiteStorage implements PureeStorage {
+public class PureeSQLiteStorage extends EnhancedPureeStorage {
 
     private static final String DATABASE_NAME = "puree.db";
 
@@ -155,6 +155,7 @@ public class PureeSQLiteStorage implements PureeStorage {
         openHelper.getWritableDatabase().delete(TABLE_NAME, where, null);
     }
 
+    @Override
     public void delete(String type, long ageMillis) {
         String where = COLUMN_NAME_TYPE + " = ? AND "
                 + COLUMN_NAME_CREATED_AT + " <= ?";

--- a/puree/src/main/java/com/cookpad/puree/storage/PureeSQLiteStorage.java
+++ b/puree/src/main/java/com/cookpad/puree/storage/PureeSQLiteStorage.java
@@ -24,6 +24,8 @@ public class PureeSQLiteStorage extends SupportSQLiteOpenHelper.Callback impleme
 
     private static final String TABLE_NAME = "logs";
 
+    private static final String COLUMN_NAME_ID = "id";
+
     private static final String COLUMN_NAME_TYPE = "type";
 
     private static final String COLUMN_NAME_LOG = "log";
@@ -86,7 +88,7 @@ public class PureeSQLiteStorage extends SupportSQLiteOpenHelper.Callback impleme
     public Records select(String type, int logsPerRequest) {
         String query = "SELECT * FROM " + TABLE_NAME +
                 " WHERE " + COLUMN_NAME_TYPE + " = ?" +
-                " ORDER BY id " + getOrderType() +
+                " ORDER BY " + COLUMN_NAME_ID + " " + getOrderType() +
                 " LIMIT " + logsPerRequest;
         Cursor cursor = openHelper.getReadableDatabase().query(query, new String[]{type});
 
@@ -140,7 +142,7 @@ public class PureeSQLiteStorage extends SupportSQLiteOpenHelper.Callback impleme
 
     @Override
     public void delete(Records records) {
-        String where = "id IN (" + records.getIdsAsString() + ")";
+        String where = COLUMN_NAME_ID + " IN (" + records.getIdsAsString() + ")";
         openHelper.getWritableDatabase().delete(TABLE_NAME, where, null);
     }
 
@@ -158,8 +160,8 @@ public class PureeSQLiteStorage extends SupportSQLiteOpenHelper.Callback impleme
     public void truncateBufferedLogs(int maxRecords) {
         int recordSize = getRecordCount();
         if (recordSize > maxRecords) {
-            String where = "id IN ( SELECT id FROM " + TABLE_NAME +
-                    " ORDER BY id ASC LIMIT " + (recordSize - maxRecords) + ")";
+            String where = COLUMN_NAME_ID + " IN ( SELECT id FROM " + TABLE_NAME +
+                    " ORDER BY " + COLUMN_NAME_ID + " ASC LIMIT " + (recordSize - maxRecords) + ")";
             openHelper.getWritableDatabase().delete(TABLE_NAME, where, null);
         }
     }
@@ -172,7 +174,7 @@ public class PureeSQLiteStorage extends SupportSQLiteOpenHelper.Callback impleme
     @Override
     public void onCreate(SupportSQLiteDatabase db) {
         String query = "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " (" +
-                "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                COLUMN_NAME_ID + " INTEGER PRIMARY KEY AUTOINCREMENT," +
                 COLUMN_NAME_TYPE + " TEXT," +
                 COLUMN_NAME_LOG + " TEXT," +
                 COLUMN_NAME_CREATED_AT + " INTEGER" +


### PR DESCRIPTION
This PR adds a feature that allows purging of old logs stored in the buffer. This can be configured through `OutputConfiguration#setPurgeAgeMillis()`

To support this feature, `PureeStorage` needs to be modified to record log date and allow deletion based on log age. Since `PureeStorage` is an interface, modifying it directly will break existing clients that implements it so a new abstract class called `EnhancedPureeStorage` was introduced to add the new methods and support future changes.

The tests and demo project were also updated to support the new feature.